### PR TITLE
Update UNIXPATH from logpush

### DIFF
--- a/patterns/grok.pattern
+++ b/patterns/grok.pattern
@@ -34,7 +34,7 @@ HOSTPORT %{IPORHOST}:%{POSINT}
 
 # paths
 PATH (?:%{UNIXPATH}|%{WINPATH})
-UNIXPATH (/([\w_%!$@:.,+~-]+|\\.)*)+
+UNIXPATH (/[[[:alnum:]]_%!$@:.,+~-]*)+
 TTY (?:/dev/(pts|tty([pq])?)(\w+)?/?(?:[0-9]+))
 WINPATH (?>[A-Za-z]+:|\\)(?:\\[^\\?*]*)+
 URIPROTO [A-Za-z]([A-Za-z0-9+\-.]+)+


### PR DESCRIPTION
To prevent infinite back tracking.
    
This change is a mindless port of [logstash-pattern-core](https://github.com/logstash-plugins/logstash-patterns-core/blob/main/patterns/legacy/grok-patterns#L37) which was made to addrses [%UNIXPATH can cause RegEx DOS](https://github.com/logstash-plugins/logstash-patterns-core/issues/159)